### PR TITLE
[ADD] 정기 구독 해제 기능 추가

### DIFF
--- a/api/controllers/refundController.js
+++ b/api/controllers/refundController.js
@@ -9,6 +9,17 @@ const getRefunds = asyncErrorHandler(async (request, response) => {
   return response.status(200).json({ data: results });
 });
 
+const cancelSubscription = asyncErrorHandler(async (request, response) => {
+  const userId = request.userId;
+  const subscriptionId = request.body.subscriptionId;
+
+  if (!userId || !subscriptionId)
+    throw customError("cancel subscription fail", 400);
+  const result = await refundService.cancelSubscription(userId, subscriptionId);
+  return response.status(200).json({ message: "subscription cancelled" });
+});
+
 module.exports = {
   getRefunds,
+  cancelSubscription,
 };

--- a/api/routes/refundRoutes.js
+++ b/api/routes/refundRoutes.js
@@ -5,5 +5,10 @@ const refundController = require("../controllers/refundController");
 const router = express.Router();
 
 router.get("", validateToken, refundController.getRefunds);
+router.post(
+  "/subscription",
+  validateToken,
+  refundController.cancelSubscription
+);
 
 module.exports = { router };

--- a/api/services/refundService.js
+++ b/api/services/refundService.js
@@ -1,9 +1,41 @@
+const { customError } = require("../middlewares/error");
 const refundDao = require("../models/refundDao");
+const axios = require("axios");
 
 const getRefunds = async (userId) => {
   return await refundDao.getRefunds(userId);
 };
 
+const cancelSubscription = async (userId, subscriptionId) => {
+  const [check] = await refundDao.check(subscriptionId);
+  if (!check) throw customError("Cannot cancel subscription", 400);
+
+  const kakaoPay = await axios.post(
+    "https://kapi.kakao.com/v1/payment/manage/subscription/inactive",
+    {},
+    {
+      headers: {
+        Authorization: `KakaoAK ${process.env.KAKAO_ADMIN}`,
+        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+      params: {
+        cid: "TCSUBSCRIP",
+        sid: check.billing_key,
+      },
+    }
+  );
+
+  if (kakaoPay.status != 200) {
+    throw customError("Cannot cancel subscription", 400);
+  }
+  return await refundDao.cancelSubscription(
+    userId,
+    subscriptionId,
+    check.expiration_at
+  );
+};
+
 module.exports = {
   getRefunds,
+  cancelSubscription,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- [ADD] 정기 구독 해제 기능 추가

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- [ADD] 정기 구독 해제 기능 추가
- 테스트 코드 제외
- 결제와 달리 정기 결제 취소는 문자가 따로 오지 않는 것으로 확인 되었습니다.
- 따라서 사진에 결제 취소에 따른 response 값을 console.log를 통해 INACTIVE로 변경되었다는 것을 확인할 수 있었습니다.

-subscriptions table 에서 
next_pay_at이 예로 들어 2023-02-11라면 
expire_at은 2023-02-12 00:00:00으로 설정되어있습니다.
따라서 mysql 내의 스케쥴러를 이용하여 
따로 activation 값이 변경되게 하였습니다.


<br />

## :: 테스트 결과 이미지
1. Server가 잘 동작하는지 확인할 수 있는 Terminal 캡쳐 이미지
2. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
3. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
4. DB 작업 PR인 경우 Table 생성 및 수정 결과에 대해 확인할 수 있는 이미지
<img width="546" alt="image" src="https://user-images.githubusercontent.com/78012131/217667391-b12cec93-fb1c-4d80-9845-a893a3b8af35.png">

<br />

## :: 기타 질문 및 특이 사항
